### PR TITLE
Deprecate repo in favor of entireio/skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # Entire Plugin for Claude Code
 
+> [!WARNING]
+> **This repository is deprecated.**
+>
+> Development has moved to [**entireio/skills**](https://github.com/entireio/skills). Please use that repository for the latest versions, installation instructions, and new features. This repo is no longer maintained and will not receive updates.
+
+---
+
 Tools for understanding code intent by tracing changes back to original session transcripts.
 
 ## Installation


### PR DESCRIPTION
## Summary
- Adds a deprecation warning banner to the top of the README directing users to [entireio/skills](https://github.com/entireio/skills), which is the new home for this plugin.

## Test plan
- [x] Verify the banner renders correctly on GitHub (GFM `[!WARNING]` alert).
- [x] Confirm the link to `entireio/skills` resolves.
- [x] After merge, consider archiving this repository via GitHub settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change; no code paths or runtime behavior are affected.
> 
> **Overview**
> Adds a prominent GitHub-flavored warning banner at the top of `README.md` marking this repository as deprecated and directing users to `entireio/skills` for ongoing development, installation instructions, and new features.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c103d64cc18860db787253fc8790d2b768ab6c15. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->